### PR TITLE
Fix foedselsnummer.js for 2000s births

### DIFF
--- a/JavaScript/foedselsnummer.js
+++ b/JavaScript/foedselsnummer.js
@@ -87,7 +87,7 @@ function getDateFromNorwegianPersonalIdentificationNumber(fnummer, failures){
     }else if(individnummer >= 900 && individnummer <= 999 && year >= 40 && year <= 99){
       year = year + 1900;
     }else if(individnummer >= 500 && individnummer <= 999 && year >= 0 && year <= 39){
-      year = year + 1900;
+      year = year + 2000;
     }else{
       failures.doubleValue = failures.doubleValue + 1;
     }


### PR DESCRIPTION
Proposed fix for issue here: https://github.com/InductiveComputerScience/fodselsnummer/issues/1

Information found here: https://blog.tedd.no/2016/12/07/norske-fodselsnummer-i-c-norwegian-national-id-numbers-in-c/ (See: the IndividualNumberControlRange method on line 52)

@martinfjohansen , let me know what you think. I am basing this change off of another source, but that could potentially be wrong. 

Thanks!